### PR TITLE
QD-13871 Add Qodana for Rust (QDRST) linter support

### DIFF
--- a/vscode/qodana/src/core/cli/language.ts
+++ b/vscode/qodana/src/core/cli/language.ts
@@ -15,6 +15,7 @@ extensionToLanguageMap.set('vb', ['C#', 'F#', 'Visual Basic .NET']);
 extensionToLanguageMap.set('c', ['C/C++']);
 extensionToLanguageMap.set('cpp', ['C/C++']);
 extensionToLanguageMap.set('rb', ['Ruby']);
+extensionToLanguageMap.set('rs', ['Rust']);
 
 let languageToProductCodeMap = new Map<string, string[]>();
 languageToProductCodeMap.set('C/C++', ['QDCL', 'QDNET', 'QDCLC']);
@@ -29,6 +30,7 @@ languageToProductCodeMap.set('C#', ['QDNET', 'QDNETC']);
 languageToProductCodeMap.set('F#', ['QDNET']);
 languageToProductCodeMap.set('Visual Basic .NET', ['QDNET', 'QDNETC']);
 languageToProductCodeMap.set('Ruby', ['QDRUBY']);
+languageToProductCodeMap.set('Rust', ['QDRST']);
 
 // every code that ends with C is a community code
 let communityCodes = new Set<string>();
@@ -43,6 +45,7 @@ eapCodes.add('QDNETC');
 eapCodes.add('QDCLC');
 eapCodes.add('QDCPP');
 eapCodes.add('QDRUBY');
+eapCodes.add('QDRST');
 
 let productCodeToDockerImageMap = new Map<string, string>();
 productCodeToDockerImageMap.set('QDANDC', 'qodana-jvm-android');
@@ -60,6 +63,7 @@ productCodeToDockerImageMap.set('QDJVM', 'qodana-jvm');
 productCodeToDockerImageMap.set('QDJVMC', 'qodana-jvm-community');
 productCodeToDockerImageMap.set('QDCPP', 'qodana-cpp');
 productCodeToDockerImageMap.set('QDRUBY', 'qodana-ruby');
+productCodeToDockerImageMap.set('QDRST', 'qodana-rust');
 
 const eapPrefix = '-EAP';
 

--- a/vscode/qodana/src/test/suite/language.test.ts
+++ b/vscode/qodana/src/test/suite/language.test.ts
@@ -88,6 +88,17 @@ describe('Language/Linter Selection Tests', () => {
         assert.equal(choiceStub.called, true);
     });
 
+    it('9: getLinters should return QDRST for Rust language', () => {
+        const { communityLinters, paidLinters } = getLinters(['Rust']);
+        assert.ok(arraysAreEqual(communityLinters, []));
+        assert.ok(arraysAreEqual(paidLinters, ['QDRST']));
+    });
+
+    it('10: getLinterByCode should return EAP Docker image for QDRST', () => {
+        const linterImage = getLinterByCode('QDRST');
+        assert.equal(linterImage, 'qodana-rust-EAP');
+    });
+
     function arraysAreEqual<T>(arr1: T[], arr2: T[]): boolean {
         if (arr1.length !== arr2.length) { return false; }
         for (let i = 0; i < arr1.length; i++) {


### PR DESCRIPTION
- Add Rust (`.rs`) file extension mapping to `Rust` language
- Map `Rust` language to `QDRST` product code
- Register `QDRST` as EAP-only linter
- Map `QDRST` to `qodana-rust` Docker image
- Add tests for Rust linter resolution