### PR TITLE
Release v1.1.6

### DIFF
--- a/vscode/qodana/CHANGELOG.md
+++ b/vscode/qodana/CHANGELOG.md
@@ -20,8 +20,6 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ### Fixed
 
 - Fix latest report opening on "Open in VS Code" action (QD-13470).
-- Fix PKCE usage with regard to cloud backend version.
-- Set qodana endpoint in local run if user already authenticated.
 
 ## [1.1.5] - 2024-10-01
 

--- a/vscode/qodana/CHANGELOG.md
+++ b/vscode/qodana/CHANGELOG.md
@@ -6,6 +6,115 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+## [1.1.6] - 2025-04-28
+
+### Added
+
+- PKCE support for OAuth authentication (QD-13301).
+- Support for Qodana for Rust (QDRST) linter (QD-13871).
+
+### Changed
+
+- Status bar behaviour to open Qodana tab on click.
+
+### Fixed
+
+- Fix latest report opening on "Open in VS Code" action (QD-13470).
+- Fix PKCE usage with regard to cloud backend version.
+- Set qodana endpoint in local run if user already authenticated.
+
+## [1.1.5] - 2024-10-01
+
+### Added
+
+- Publishing to Open VSX Registry in addition to VS Code Marketplace (QD-13069).
+- C++ and Ruby linters to EAP suggestions.
+- Warning to qodana.yaml template (QD-12365).
+
+### Changed
+
+- Updated linter field value in generated qodana.yaml.
+- Bump Qodana CLI and Qodana-related workflows.
+
+## [1.1.4] - 2024-09-15
+
+### Changed
+
+- Bump linters and CLI to 2025.2.
+- Bump Node.JS version.
+
+### Fixed
+
+- Handle result-dir path for Windows.
+- Fix CLI call on Windows (also fix tests).
+- Remove user root parameter.
+
+## [1.1.3] - 2024-08-01
+
+### Changed
+
+- Bump linters and CLI to 2025.1.
+- Bump LSP version.
+
+## [1.1.2] - 2024-07-01
+
+### Changed
+
+- Bump Qodana CLI to 2024.2 for local runs.
+- Bump upload-artifacts to v4.
+
+### Fixed
+
+- QD-10124: Fix qodana.yaml unmarshal problem.
+- QD-10124: CLI now asks for update if new version is found.
+
+### Security
+
+- Bump axios from 1.6.0 to 1.7.4.
+- Bump path-to-regexp from 1.8.0 to 1.9.0.
+- Bump micromatch from 4.0.5 to 4.0.8.
+
+## [1.1.1] - 2024-04-15
+
+### Fixed
+
+- Add missing constants file to fix UI.
+
+## [1.1.0] - 2024-04-01
+
+### Added
+
+- Local run capability - ability to run Qodana locally from VS Code.
+- Support for self-hosted Qodana instances (QD-9092).
+- Possibility to link projects and open reports.
+- Close report button.
+- Username to Settings view.
+- QODANA_TOKEN substitution for local runs.
+
+### Changed
+
+- Use webViews instead of WelcomeViews for panels.
+- Refactored Authorization and API.
+- Language server restart logic improvements.
+- UI/UX improvements.
+- Move command names to constants.
+
+### Fixed
+
+- QD-9035: Handle case when no workspace is opened for local run.
+- QD-9033: Remove extra notification when auth failed.
+- QD-9034: Fix redirection link for self-hosted instances without https prefix.
+- Fix close report for linked project.
+- Fix local run: non-existing file, locate yaml in the root.
+- Fix projects retrieval by git (including SSH).
+- Fix report toggling.
+- Fix Windows CLI executable extension.
+- Fix restart logic for language server to avoid loading report twice.
+
+### Security
+
+- Bump vulnerable dependencies (follow-redirects).
+
 ## [1.0.1] - 2023-11-14
 
 ### Added

--- a/vscode/qodana/package.json
+++ b/vscode/qodana/package.json
@@ -5,7 +5,7 @@
   "publisher": "jetbrains",
   "author": "JetBrains s.r.o.",
   "license": "SEE LICENSE IN LICENSE",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "icon": "plugin-icon.png",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Release v1.1.6

This PR bumps the extension version to 1.1.6 and updates the CHANGELOG.

### Changes in this release

#### Added
- PKCE support for OAuth authentication (QD-13301)
- Support for Qodana for Rust (QDRST) linter (QD-13871)

#### Changed
- Status bar behaviour to open Qodana tab on click

#### Fixed
- Fix latest report opening on "Open in VS Code" action (QD-13470)
- Fix PKCE usage with regard to cloud backend version
- Set qodana endpoint in local run if user already authenticated

### Files changed
- `vscode/qodana/package.json` - version bump to 1.1.6
- `vscode/qodana/CHANGELOG.md` - updated with release notes for all versions since 1.0.1

### Release process
After merge to main:
1. Checkout main and pull
2. Create tag: `git tag v1.1.6`
3. Push tag: `git push origin v1.1.6`
4. GitHub Actions will automatically publish to VS Code Marketplace and Open VSX