### PR TITLE
fix: QD-14673 Move tag to new commit after version updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,11 @@ jobs:
           git add .
           git commit -m "chore: prepare release $VERSION"
           git push
+
+          # Move the tag to the new commit
+          echo "Moving tag $TAG to the new commit"
+          git tag -f $TAG
+          git push -f origin $TAG
         else
           echo "No changes to commit"
         fi


### PR DESCRIPTION
## Summary
- Fixed release process to move git tag to the final commit after version updates

## Problem
When a release tag is created, the CI workflow runs `prepare-release.js` which updates version files (package.json, package-lock.json, CHANGELOG.md, etc.) and creates a commit. However, the original tag remains pointing to the commit **before** these updates, which means:
- The tagged commit has outdated version numbers
- The release doesn't include the changelog entry
- The workflow creates a "prepare release" commit that's not included in the release

## Solution
After pushing the "prepare release" commit, the workflow now:
1. Forces the tag to move to the new commit: `git tag -f $TAG`
2. Force-pushes the updated tag: `git push -f origin $TAG`

This ensures the tag always points to the commit with updated version files and changelog.

## Test plan
- [ ] Create a test tag and verify the workflow updates it correctly
- [ ] Verify the tag points to the commit with updated versions
- [ ] Verify no issues with concurrent workflow runs

## Changes
- Modified `.github/workflows/ci.yml` to add tag reassignment after release preparation

Related issue: https://youtrack.jetbrains.com/issue/QD-14673