### PR TITLE
fix: checkout main before committing in release workflow (QD-14520)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,10 @@ jobs:
           git config user.name github-actions
           git config user.email github-actions@github.com
           git add .
+
+          # Switch to main branch before committing (staged changes will be preserved)
+          git checkout main
+
           git commit -m "chore: prepare release $VERSION"
           git push
 


### PR DESCRIPTION
## Summary
Fixes the release workflow failing with `fatal: You are not currently on a branch` error when pushing release preparation commits.

## Problem
When the workflow is triggered by a tag push, `actions/checkout` checks out the tag in detached HEAD state. The workflow tried to commit and push from detached HEAD, which fails.

## Solution
Added `git checkout main` after staging changes but before committing. Staged changes are preserved during branch switch, so no data is lost.

## Test plan
- [x] Triggered by tag v1.1.6 push
- [x] Verified workflow fails with expected error
- [x] Applied fix
- [ ] Will be verified when merging and creating next release tag

🤖 Related to QD-14520