### PR TITLE
fix: QD-15189 replace deprecated vsce with @vscode/vsce in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
       with:
         node-version: '20.18'
     - name: Install dependencies
-      run: npm install -g vsce ovsx && npm ci
+      run: npm install -g @vscode/vsce ovsx && npm ci
       working-directory: vscode/qodana
     - name: Run ts tests
       run: xvfb-run -a npm run test


### PR DESCRIPTION
## Summary

- Replace `vsce` with `@vscode/vsce` in CI install step to fix Windows build failure
- Old `vsce@2.15.0` tries to build native `keytar` module via node-gyp which fails on Windows with EPERM error

## YouTrack

- [QD-15189](https://youtrack.jetbrains.com/issue/QD-15189) — Fix Windows CI build failure